### PR TITLE
Fix location of proj4 resource files

### DIFF
--- a/src/main/java/org/locationtech/proj4j/io/Proj4FileReader.java
+++ b/src/main/java/org/locationtech/proj4j/io/Proj4FileReader.java
@@ -35,7 +35,7 @@ public class Proj4FileReader {
         // TODO: use simpler parser than StreamTokenizer for speed and flexibility
         // TODO: parse CSes line-at-a-time (this allows preserving CS param string for later access)
 
-        String filename = "/nad/" + authorityCode.toLowerCase();
+        String filename = "/proj4/nad/" + authorityCode.toLowerCase();
         InputStream inStr = Proj4FileReader.class.getResourceAsStream(filename);
         if (inStr == null) {
             throw new IllegalStateException("Unable to access CRS file: " + filename);


### PR DESCRIPTION
While '/nad/' is the location in the original proj4j/proj4j repo, this version needs the filename string pointed to '/proj4/nad/'.