### PR TITLE
Make projection list accessible

### DIFF
--- a/src/main/java/org/locationtech/proj4j/Registry.java
+++ b/src/main/java/org/locationtech/proj4j/Registry.java
@@ -137,6 +137,7 @@ public class Registry {
             } catch (IllegalAccessException e) {
                 e.printStackTrace();
             } catch (InstantiationException e) {
+                System.err.println("Cannot instantiate projection " + name + " [" + cls.getName() + "]");
                 e.printStackTrace();
             }
         }

--- a/src/main/java/org/locationtech/proj4j/Registry.java
+++ b/src/main/java/org/locationtech/proj4j/Registry.java
@@ -150,7 +150,9 @@ public class Registry {
         for (String name : projRegistry.keySet()) {
             Projection projection = getProjection(name);
 
-            projections.add(projection);
+            if (projection != null) {
+                projections.add(projection);
+            }
         }
 
         return projections;

--- a/src/main/java/org/locationtech/proj4j/Registry.java
+++ b/src/main/java/org/locationtech/proj4j/Registry.java
@@ -15,7 +15,9 @@
  */
 package org.locationtech.proj4j;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.locationtech.proj4j.datum.Datum;
@@ -139,6 +141,18 @@ public class Registry {
             }
         }
         return null;
+    }
+
+    public List<Projection> getProjections() {
+        List<Projection> projections = new ArrayList<>();
+
+        for (String name : projRegistry.keySet()) {
+            Projection projection = getProjection(name);
+
+            projections.add(projection);
+        }
+
+        return projections;
     }
 
     private synchronized void initialize() {


### PR DESCRIPTION
Method getProjection() in class Registry allows to obtain an instance of Projection given its name.
Internally, Registry maintains an internal list of Projections names <-> classes mappings and creates an instance of the correct class.

This pull request adds a method to retrieve a complete list of all usable Projection instances.

NOTE: if you run the code you will discover that there are 3 projections configured in Registry that cannot be allocated:
- alsk
- apian
- bacon

They should probably be commented out in initialize() until they are property implemented (they point to class Projection, which is abstract and cannot be instanced).
The code in my pull request handles gracefully these non-instanceable projections.