### PR TITLE
Add Projection Equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2019-09-05
 
 ### Added
-- Added `GeostationarySatelliteProjection`/`geos` projection by [@Yaqiang](https://github.com/Yaqiang)
-- Registry.getProjections exposes all available projects by [@noberasco](https://github.com/noberasco)
-- OSGi compatibility by [@Neutius](https://github.com/Neutius)
+- Added `GeostationarySatelliteProjection`/`geos` projection
+- Registry.getProjections exposes all available projects
+- OSGi compatibility
 
 ### Changed
-- Parse `geos` (Geostationary Satellite Projection) proj4 strings by [@pomadchin](https://github.com/pomadchin)
-- Projection units reported as meters by default by [@bosborn](https://github.com/bosborn)
-- BasicCoordinateTransform now thread-safe by [@sebasbaumh](https://github.com/sebasbaumh)
-- Improve CRS Caching performance by [@pomadchin](https://github.com/pomadchin)
-- CoordinateReferenceSystem.equals considered logical equality by [@pomadchin](https://github.com/pomadchin)
+- Parse `geos` (Geostationary Satellite Projection) proj4 strings
+- Projection units reported as meters by default
+- BasicCoordinateTransform now thread-safe
+- Improve CRS Caching performance
+- CoordinateReferenceSystem.equals considered logical equality
+- Projection.equals considered logical equality
 
 ## [1.0.0] - 2019-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2019-09-05
+
 ### Added
 - Added `GeostationarySatelliteProjection`/`geos` projection by [@Yaqiang](https://github.com/Yaqiang)
 - Registry.getProjections exposes all available projects by [@noberasco](https://github.com/noberasco)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.locationtech.proj4j</groupId>
     <artifactId>proj4j</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>bundle</packaging>
     <name>Proj4J</name>
     <url>https://github.com/locationtech/proj4j</url>
@@ -120,7 +120,7 @@
 					</instructions>
 					<niceManifest>true</niceManifest>
 				</configuration>
-			</plugin>			
+			</plugin>
 
             <!-- Maven Central Publish -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.locationtech.proj4j</groupId>
     <artifactId>proj4j</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Proj4J</name>
     <url>https://github.com/locationtech/proj4j</url>

--- a/src/main/java/org/locationtech/proj4j/CoordinateReferenceSystem.java
+++ b/src/main/java/org/locationtech/proj4j/CoordinateReferenceSystem.java
@@ -129,7 +129,8 @@ public class CoordinateReferenceSystem implements java.io.Serializable {
         }
         if (that instanceof CoordinateReferenceSystem) {
             CoordinateReferenceSystem cr = (CoordinateReferenceSystem) that;
-            return name.equals(cr.name) && datum.isEqual(cr.getDatum()) && Arrays.equals(params, cr.params);
+            // Projection equality contains Ellipsoid and Unit equality
+            return datum.isEqual(cr.getDatum()) && proj.equals(cr.proj);
         }
         return false;
     }

--- a/src/main/java/org/locationtech/proj4j/datum/AxisOrder.java
+++ b/src/main/java/org/locationtech/proj4j/datum/AxisOrder.java
@@ -86,7 +86,7 @@ public final class AxisOrder implements Serializable {
         public abstract void toENU(double x, ProjCoordinate c);
     }
 
-    public final static AxisOrder ENU = 
+    public final static AxisOrder ENU =
         new AxisOrder(Axis.Easting, Axis.Northing, Axis.Up);
 
     private final Axis x, y, z;

--- a/src/main/java/org/locationtech/proj4j/proj/AiryProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/AiryProjection.java
@@ -45,7 +45,7 @@ public class AiryProjection extends Projection {
 		maxLongitude = Math.toRadians(90);
 		initialize();
 	}
-	
+
 	public ProjCoordinate project(double lplam, double lpphi, ProjCoordinate out) {
 		double sinlam, coslam, cosphi, sinphi, t, s, Krho, cosz;
 

--- a/src/main/java/org/locationtech/proj4j/proj/AitoffProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/AitoffProjection.java
@@ -23,7 +23,7 @@ import org.locationtech.proj4j.ProjCoordinate;
 
 
 public class AitoffProjection extends PseudoCylindricalProjection {
-	
+
 	protected final static int AITOFF = 0;
 	protected final static int WINKEL = 1;
 
@@ -65,7 +65,7 @@ public class AitoffProjection extends PseudoCylindricalProjection {
 				cosphi1 = 0.636619772367581343;
 		}
 	}
-	
+
 	public boolean hasInverse() {
 		return false;
 	}
@@ -74,5 +74,15 @@ public class AitoffProjection extends PseudoCylindricalProjection {
 		return winkel ? "Winkel Tripel" : "Aitoff";
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof AitoffProjection) {
+					AitoffProjection p = (AitoffProjection) that;
+					return (winkel == p.winkel && super.equals(that));
+			}
+			return false;
+	}
 }
-

--- a/src/main/java/org/locationtech/proj4j/proj/AzimuthalProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/AzimuthalProjection.java
@@ -27,11 +27,11 @@ public abstract class AzimuthalProjection extends Projection {
 	public final static int SOUTH_POLE = 2;
 	public final static int EQUATOR = 3;
 	public final static int OBLIQUE = 4;
-	
+
 	protected int mode;
 	protected double sinphi0, cosphi0;
 	private double mapRadius = 90.0;
-	
+
 	public AzimuthalProjection() {
 		this( Math.toRadians(45.0), Math.toRadians(45.0) );
 	}
@@ -41,7 +41,7 @@ public abstract class AzimuthalProjection extends Projection {
 		this.projectionLongitude = projectionLongitude;
 		initialize();
 	}
-	
+
 	public void initialize() {
 		super.initialize();
 		if (Math.abs(Math.abs(projectionLatitude) - ProjectionMath.HALFPI) < EPS10)
@@ -69,5 +69,20 @@ public abstract class AzimuthalProjection extends Projection {
 		return mapRadius;
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof AzimuthalProjection) {
+					AzimuthalProjection p = (AzimuthalProjection) that;
+					return (
+						mode == p.mode &&
+						sinphi0 == p.sinphi0 &&
+						cosphi0 == p.cosphi0 &&
+						mapRadius == p.mapRadius &&
+						super.equals(that));
+			}
+			return false;
+	}
 }
-

--- a/src/main/java/org/locationtech/proj4j/proj/BipolarProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/BipolarProjection.java
@@ -54,7 +54,7 @@ public class BipolarProjection extends Projection {
 		minLongitude = Math.toRadians(-90);
 		maxLongitude = Math.toRadians(90);
 	}
-	
+
 	public ProjCoordinate project(double lplam, double lpphi, ProjCoordinate out) {
 		double cphi, sphi, tphi, t, al, Az, z, Av, cdlam, sdlam, r;
 		boolean tag;
@@ -112,8 +112,8 @@ public class BipolarProjection extends Projection {
 		out.y += (tag ? -r : r) * Math.cos(t);
 		if (noskew) {
 			t = out.x;
-			out.x = -out.x * cAzc - out.y * sAzc; 
-			out.y = -out.y * cAzc + t * sAzc; 
+			out.x = -out.x * cAzc - out.y * sAzc;
+			out.y = -out.y * cAzc + t * sAzc;
 		}
 		return out;
 	}
@@ -125,8 +125,8 @@ public class BipolarProjection extends Projection {
 
 		if (noskew) {
 			t = xyx;
-			out.x = -xyx * cAzc + xyy * sAzc; 
-			out.y = -xyy * cAzc - t * sAzc; 
+			out.x = -xyx * cAzc + xyy * sAzc;
+			out.y = -xyy * cAzc - t * sAzc;
 		}
 		if (neg = (xyx < 0.)) {
 			out.y = rhoc - xyy;

--- a/src/main/java/org/locationtech/proj4j/proj/CentralCylindricalProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/CentralCylindricalProjection.java
@@ -25,15 +25,13 @@ import org.locationtech.proj4j.util.ProjectionMath;
 
 public class CentralCylindricalProjection extends CylindricalProjection {
 
-	private double ap;
-
 	private final static double EPS10 = 1.e-10;
 
 	public CentralCylindricalProjection() {
 		minLatitude = Math.toRadians(-80);
 		maxLatitude = Math.toRadians(80);
 	}
-	
+
 	public ProjCoordinate project(double lplam, double lpphi, ProjCoordinate out) {
 		if (Math.abs(Math.abs(lpphi) - ProjectionMath.HALFPI) <= EPS10) throw new ProjectionException("F");
 		out.x = lplam;

--- a/src/main/java/org/locationtech/proj4j/proj/CylindricalEqualAreaProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/CylindricalEqualAreaProjection.java
@@ -31,14 +31,14 @@ public class CylindricalEqualAreaProjection extends Projection {
 	public CylindricalEqualAreaProjection() {
 		this(0.0, 0.0, 0.0);
 	}
-	
+
 	public CylindricalEqualAreaProjection(double projectionLatitude, double projectionLongitude, double trueScaleLatitude) {
 		this.projectionLatitude = projectionLatitude;
 		this.projectionLongitude = projectionLongitude;
 		this.trueScaleLatitude = trueScaleLatitude;
 		initialize();
 	}
-	
+
 	public void initialize() {
 		super.initialize();
 		double t = trueScaleLatitude;
@@ -51,7 +51,7 @@ public class CylindricalEqualAreaProjection extends Projection {
 			qp = ProjectionMath.qsfn(1., e, one_es);
 		}
 	}
-	
+
 	public ProjCoordinate project(double lam, double phi, ProjCoordinate xy) {
 		if (spherical) {
 			xy.x = scaleFactor * lam;
@@ -90,4 +90,3 @@ public class CylindricalEqualAreaProjection extends Projection {
 	}
 
 }
-

--- a/src/main/java/org/locationtech/proj4j/proj/GeostationarySatelliteProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/GeostationarySatelliteProjection.java
@@ -14,12 +14,17 @@ import org.locationtech.proj4j.util.ProjectionMath;
  */
 public class GeostationarySatelliteProjection extends Projection {
 
+    /**
+     * Height of orbit - Geostationary satellite projection
+     */
+    protected double heightOfOrbit = 35785831.0;
+
     private double _radiusP;
     private double _radiusP2;
     private double _radiusPInv2;
     private double _radiusG;
     private double _radiusG1;
-    private double _c;    
+    private double _c;
 
     /**
      * Constructor
@@ -41,6 +46,17 @@ public class GeostationarySatelliteProjection extends Projection {
         } else {
             _radiusP = _radiusP2 = _radiusPInv2 = 1.0;
         }
+    }
+
+
+    @Override
+    public double getHeightOfOrbit(){
+        return this.heightOfOrbit;
+    }
+
+    @Override
+    public void setHeightOfOrbit(double h){
+        this.heightOfOrbit = h;
     }
 
     @Override
@@ -187,4 +203,16 @@ public class GeostationarySatelliteProjection extends Projection {
     public String toString() {
         return "Geostationary Satellite";
     }
+
+    @Override
+	public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+        if (that instanceof GeostationarySatelliteProjection) {
+            GeostationarySatelliteProjection p = (GeostationarySatelliteProjection) that;
+            return (this.heightOfOrbit == p.heightOfOrbit) && super.equals(that);
+        }
+        return false;
+	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/HammerProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/HammerProjection.java
@@ -30,7 +30,7 @@ public class HammerProjection extends PseudoCylindricalProjection {
 
 	public HammerProjection() {
 	}
-	
+
 	public ProjCoordinate project(double lplam, double lpphi, ProjCoordinate xy) {
 		double cosphi, d;
 
@@ -66,21 +66,35 @@ public class HammerProjection extends PseudoCylindricalProjection {
 	public void setW( double w ) {
 		this.w = w;
 	}
-	
+
 	public double getW() {
 		return w;
 	}
-	
+
 	public void setM( double m ) {
 		this.m = m;
 	}
-	
+
 	public double getM() {
 		return m;
 	}
-	
+
 	public String toString() {
 		return "Hammer & Eckert-Greifendorff";
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof HammerProjection) {
+					HammerProjection p = (HammerProjection) that;
+					return (
+						m == p.m &&
+						w == p.w &&
+						super.equals(that));
+			}
+			return false;
+	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/LagrangeProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/LagrangeProjection.java
@@ -53,7 +53,7 @@ public class LagrangeProjection extends Projection {
 	public void setW( double w ) {
 		this.rw = w;
 	}
-	
+
 	public double getW() {
 		return rw;
 	}
@@ -75,7 +75,7 @@ public class LagrangeProjection extends Projection {
 	public boolean isConformal() {
 		return true;
 	}
-	
+
 	public boolean hasInverse() {
 		return false;
 	}
@@ -84,4 +84,15 @@ public class LagrangeProjection extends Projection {
 		return "Lagrange";
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof LagrangeProjection) {
+					LagrangeProjection p = (LagrangeProjection) that;
+					return (rw == p.rw) && super.equals(that);
+			}
+			return false;
+	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/MolleweideProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/MolleweideProjection.java
@@ -36,7 +36,7 @@ public class MolleweideProjection extends PseudoCylindricalProjection {
 	public MolleweideProjection() {
 		this(Math.PI/2);
 	}
-	
+
 	public MolleweideProjection(int type) {
 		this.type = type;
 		switch (type) {
@@ -54,11 +54,11 @@ public class MolleweideProjection extends PseudoCylindricalProjection {
 			break;
 		}
 	}
-	
+
 	public MolleweideProjection(double p) {
 		init(p);
 	}
-	
+
 	public void init(double p) {
 		double r, sp, p2 = p + p;
 
@@ -96,7 +96,7 @@ public class MolleweideProjection extends PseudoCylindricalProjection {
 
 	public ProjCoordinate projectInverse(double x, double y, ProjCoordinate lp) {
 		double lat, lon;
-		
+
 		lat = Math.asin(y / cy);
 		lon = x / (cx * Math.cos(lat));
 		lat += lat;
@@ -105,7 +105,7 @@ public class MolleweideProjection extends PseudoCylindricalProjection {
 		lp.y = lat;
 		return lp;
 	}
-	
+
 	public boolean hasInverse() {
 		return true;
 	}
@@ -113,7 +113,7 @@ public class MolleweideProjection extends PseudoCylindricalProjection {
 	public boolean isEqualArea() {
 	    return true;
 	}
-	 
+
 	public String toString() {
 		switch (type) {
 		case WAGNER4:
@@ -122,5 +122,22 @@ public class MolleweideProjection extends PseudoCylindricalProjection {
 			return "Wagner V";
 		}
 		return "Molleweide";
+	}
+
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof MolleweideProjection) {
+					MolleweideProjection p = (MolleweideProjection) that;
+					return (
+						type == p.type &&
+						cx == p.cx &&
+						cy == p.cy &&
+						cp == p.cp &&
+						super.equals(that));
+			}
+			return false;
 	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/ObliqueMercatorProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/ObliqueMercatorProjection.java
@@ -45,7 +45,7 @@ public class ObliqueMercatorProjection extends CylindricalProjection {
 		alpha = Math.toRadians(-45);//FIXME
 		initialize();
 	}
-	
+
 	/**
 	* Set up a projection suitable for State Plane Coordinates.
 	*/
@@ -59,7 +59,7 @@ public class ObliqueMercatorProjection extends CylindricalProjection {
 		falseNorthing = y_0;
 		initialize();
 	}
-	
+
 	public void initialize() {
 		super.initialize();
 		double con, com, cosphi0, d, f, h, l, sinphi0, p, j;
@@ -67,7 +67,7 @@ public class ObliqueMercatorProjection extends CylindricalProjection {
 		//FIXME-setup rot, alpha, longc,lon/lat1/2
 		rot = true;
     lamc = lonc;
-    
+
     // true if alpha provided
     int azi = Double.isNaN(alpha) ? 0 : 1;
 		if (azi != 0) { // alpha specified
@@ -228,4 +228,19 @@ public class ObliqueMercatorProjection extends CylindricalProjection {
 		return "Oblique Mercator";
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof ObliqueMercatorProjection) {
+					ObliqueMercatorProjection p = (ObliqueMercatorProjection) that;
+					return (
+						Gamma == p.Gamma &&
+						alpha == p.alpha &&
+						lonc == p.lonc &&
+						super.equals(that));
+			}
+			return false;
+	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/Projection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/Projection.java
@@ -16,6 +16,8 @@
 
 package org.locationtech.proj4j.proj;
 
+import java.util.NoSuchElementException;
+
 import org.locationtech.proj4j.*;
 import org.locationtech.proj4j.datum.AxisOrder;
 import org.locationtech.proj4j.datum.Ellipsoid;
@@ -103,10 +105,6 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     protected double falseNorthing = 0;
 
     /**
-     * Indicates whether a Southern Hemisphere UTM zone
-     */
-    protected boolean isSouth = false;
-    /**
      * The latitude of true scale. Only used by specific projections.
      */
     protected double trueScaleLatitude = 0.0;
@@ -191,11 +189,6 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
      * northing, vertical (up)
      */
     private AxisOrder axes = AxisOrder.ENU;
-    
-    /**
-     * Height of orbit - Geostationary satellite projection
-     */
-    protected double heightOfOrbit = 35785831.0;
 
     // Some useful constants
     protected final static double EPS10 = 1e-10;
@@ -701,12 +694,13 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
         return falseEasting;
     }
 
-    public void setSouthernHemisphere(boolean isSouth)
-    {
-        this.isSouth = isSouth;
+    public void setSouthernHemisphere(boolean isSouth) {
+        throw new NoSuchElementException();
     }
 
-    public boolean getSouthernHemisphere() { return isSouth; }
+    public boolean getSouthernHemisphere() {
+        throw new NoSuchElementException();
+    }
 
     /**
      * Set the projection scale factor. This is set to 1 by default.
@@ -767,21 +761,21 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
     public Unit getUnits() {
         return this.unit != null ? this.unit : Units.METRES;
     }
-    
+
     /**
      * Get height of orbit - Geostationary satellite projection
      * @return Height of orbit
      */
     public double getHeightOfOrbit(){
-        return this.heightOfOrbit;
+        throw new NoSuchElementException();
     }
-    
+
     /**
      * Set height of orbit - Geostationary satellite projection
      * @param h Height of orbit
      */
     public void setHeightOfOrbit(double h){
-        this.heightOfOrbit = h;
+        throw new NoSuchElementException();
     }
 
     /**
@@ -823,6 +817,38 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
 
     /** Is this "projection" longlat? Overridden in LongLatProjection. */
     public Boolean isGeographic() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+        if (that instanceof Projection) {
+            Projection p = (Projection) that;
+            // Using Double.compare when values can be NaN and should still be equal
+            return (
+                // class represents implementation of project method
+                this.getClass().equals(that.getClass()) &&
+                ellipsoid.isEqual(p.ellipsoid) &&
+                falseNorthing == p.falseNorthing &&
+                falseEasting == p.falseEasting &&
+                scaleFactor == p.scaleFactor &&
+                fromMetres == p.fromMetres &&
+                trueScaleLatitude == p.trueScaleLatitude &&
+                projectionLatitude == p.projectionLatitude &&
+                projectionLongitude == p.projectionLongitude &&
+                projectionLatitude1 == p.projectionLatitude1 &&
+                projectionLatitude2 == p.projectionLatitude2 &&
+                minLatitude == p.minLatitude &&
+                maxLatitude == p.maxLatitude &&
+                minLongitude == p.minLongitude &&
+                maxLongitude == p.maxLongitude &&
+                axes.equals(p.axes) &&
+                unit.equals(p.unit) &&
+                primeMeridian.equals(p.primeMeridian));
+        }
         return false;
     }
 }

--- a/src/main/java/org/locationtech/proj4j/proj/SimpleConicProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/SimpleConicProjection.java
@@ -44,13 +44,13 @@ public class SimpleConicProjection extends ConicProjection {
 	public SimpleConicProjection() {
 		this( EULER );
 	}
-	
+
 	public SimpleConicProjection(int type) {
 		this.type = type;
 		minLatitude = Math.toRadians(0);
 		maxLatitude = Math.toRadians(80);
 	}
-	
+
 	public String toString() {
 		return "Simple Conic";
 	}
@@ -157,7 +157,7 @@ public class SimpleConicProjection extends ConicProjection {
 		case EULER:
 			n = Math.sin(sig) * Math.sin(del) / del;
 			del *= 0.5;
-			rho_c = del / (Math.tan(del) * Math.tan(sig)) + sig;	
+			rho_c = del / (Math.tan(del) * Math.tan(sig)) + sig;
 			rho_0 = rho_c - projectionLatitude;
 			break;
 		case PCONIC:
@@ -175,5 +175,17 @@ maxLatitude = Math.toRadians(60);//FIXME
 			rho_0 = rho_c - projectionLatitude;
 			break;
 		}
+	}
+
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof SimpleConicProjection) {
+					SimpleConicProjection p = (SimpleConicProjection) that;
+					return (this.type == p.type) && super.equals(that);
+			}
+			return false;
 	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/SineTangentSeriesProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/SineTangentSeriesProjection.java
@@ -36,7 +36,7 @@ class SineTangentSeriesProjection extends ConicProjection {
 		tan_mode = mode;
 		initialize();
 	}
-	
+
 	public ProjCoordinate project(double lplam, double lpphi, ProjCoordinate xy) {
 		double c;
 
@@ -56,7 +56,7 @@ class SineTangentSeriesProjection extends ConicProjection {
 
 	public ProjCoordinate projectInverse(double xyx, double xyy, ProjCoordinate lp) {
 		double c;
-		
+
 		xyy /= C_y;
 		c = Math.cos(lp.y = tan_mode ? Math.atan(xyy) : ProjectionMath.asin(xyy));
 		lp.y /= C_p;
@@ -72,4 +72,20 @@ class SineTangentSeriesProjection extends ConicProjection {
 		return true;
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof SineTangentSeriesProjection) {
+					SineTangentSeriesProjection p = (SineTangentSeriesProjection) that;
+					return (
+						C_x == p.C_x &&
+						C_y == p.C_y &&
+						C_p == p.C_p &&
+						tan_mode == p.tan_mode &&
+						super.equals(that));
+			}
+			return false;
+	}
 }

--- a/src/main/java/org/locationtech/proj4j/proj/StereographicAzimuthalProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/StereographicAzimuthalProjection.java
@@ -25,9 +25,9 @@ import org.locationtech.proj4j.util.ProjectionMath;
 public class StereographicAzimuthalProjection extends AzimuthalProjection {
 
 	private final static double TOL = 1.e-8;
-	
+
 	private double akm1;
-	
+
 	public StereographicAzimuthalProjection() {
 		this(Math.toRadians(90.0), Math.toRadians(0.0));
 	}
@@ -36,7 +36,7 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 		super(projectionLatitude, projectionLongitude);
 		initialize();
 	}
-	
+
 	public void setupUPS(int pole) {
 		projectionLatitude = (pole == SOUTH_POLE) ? -ProjectionMath.HALFPI: ProjectionMath.HALFPI;
 		projectionLongitude = 0.0;
@@ -46,7 +46,7 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 		trueScaleLatitude = ProjectionMath.HALFPI;
 		initialize();
 	}
-	
+
 	public void initialize() {
 		double t;
 
@@ -245,14 +245,14 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 		}
 		return lp;
 	}
-	
+
 	/**
 	 * Returns true if this projection is conformal
 	 */
 	public boolean isConformal() {
 		return true;
 	}
-	
+
 	public boolean hasInverse() {
 		return true;
 	}
@@ -266,6 +266,4 @@ public class StereographicAzimuthalProjection extends AzimuthalProjection {
 	public String toString() {
 		return "Stereographic Azimuthal";
 	}
-
 }
-

--- a/src/main/java/org/locationtech/proj4j/proj/TransverseMercatorProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/TransverseMercatorProjection.java
@@ -27,7 +27,7 @@ import org.locationtech.proj4j.util.ProjectionMath;
 * Transverse Mercator Projection algorithm is taken from the USGS PROJ package.
 */
 public class TransverseMercatorProjection extends CylindricalProjection {
-	
+
 	private final static double FC1 = 1.0;
 	private final static double FC2 = 0.5;
 	private final static double FC3 = 0.16666666666666666666;
@@ -37,6 +37,10 @@ public class TransverseMercatorProjection extends CylindricalProjection {
 	private final static double FC7 = 0.02380952380952380952;
 	private final static double FC8 = 0.01785714285714285714;
 
+	/**
+	 * Indicates whether a Southern Hemisphere UTM zone
+	 */
+	protected boolean isSouth = false;
   private int utmZone = -1;
 	private double esp;
 	private double ml0;
@@ -50,7 +54,7 @@ public class TransverseMercatorProjection extends CylindricalProjection {
 		maxLongitude = Math.toRadians(90);
 		initialize();
 	}
-	
+
 	/**
 	* Set up a projection suitable for State Plane Coordinates.
 	*/
@@ -63,14 +67,24 @@ public class TransverseMercatorProjection extends CylindricalProjection {
 		falseNorthing = y_0;
 		initialize();
 	}
-	
+
+	@Override
+	public void setSouthernHemisphere(boolean isSouth) {
+		this.isSouth = isSouth;
+	}
+
+	@Override
+	public boolean getSouthernHemisphere() {
+		return isSouth;
+	}
+
 	public Object clone() {
 		TransverseMercatorProjection p = (TransverseMercatorProjection)super.clone();
 		if (en != null)
 			p.en = (double[])en.clone();
 		return p;
 	}
-	
+
 	public boolean isRectilinear() {
 		return false;
 	}
@@ -95,7 +109,7 @@ public class TransverseMercatorProjection extends CylindricalProjection {
 			return 24;
 		return (degrees + 80) / 8 + 3;
 	}
-	
+
 	public static int getZoneFromNearestMeridian(double longitude) {
 		int zone = (int)Math.floor((ProjectionMath.normalizeLongitude(longitude) + Math.PI) * 30.0 / Math.PI) + 1;
 		if (zone < 1)
@@ -104,7 +118,7 @@ public class TransverseMercatorProjection extends CylindricalProjection {
 			zone = 60;
 		return zone;
 	}
-	
+
 	public void setUTMZone(int zone) {
     utmZone = zone;
 		zone--;

--- a/src/main/java/org/locationtech/proj4j/proj/UrmaevFlatPolarSinusoidalProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/UrmaevFlatPolarSinusoidalProjection.java
@@ -33,7 +33,7 @@ public class UrmaevFlatPolarSinusoidalProjection extends Projection {
 
 	public UrmaevFlatPolarSinusoidalProjection() {
 	}
-	
+
 	public ProjCoordinate project(double lplam, double lpphi, ProjCoordinate out) {
 		out.y = ProjectionMath.asin(n * Math.sin(lpphi));
 		out.x = C_x * lplam * Math.cos(lpphi);
@@ -63,13 +63,24 @@ public class UrmaevFlatPolarSinusoidalProjection extends Projection {
 	public void setN( double n ) {
 		this.n = n;
 	}
-	
+
 	public double getN() {
 		return n;
 	}
-	
+
 	public String toString() {
 		return "Urmaev Flat-Polar Sinusoidal";
 	}
 
+	@Override
+	public boolean equals(Object that) {
+			if (this == that) {
+					return true;
+			}
+			if (that instanceof UrmaevFlatPolarSinusoidalProjection) {
+					UrmaevFlatPolarSinusoidalProjection p = (UrmaevFlatPolarSinusoidalProjection) that;
+					return (n == p.n) && super.equals(that);
+			}
+			return false;
+	}
 }

--- a/src/test/java/org/locationtech/proj4j/proj/ProjectionEqualityTest.java
+++ b/src/test/java/org/locationtech/proj4j/proj/ProjectionEqualityTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2019 Azavea
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.locationtech.proj4j.proj;
+
+import org.locationtech.proj4j.CRSFactory;
+import org.locationtech.proj4j.CoordinateReferenceSystem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests that Projection equality is semantically correct
+ */
+public class ProjectionEqualityTest
+{
+	private static CRSFactory csFactory = new CRSFactory();
+
+	@Test
+	public void utmEquality() {
+
+    CoordinateReferenceSystem cs1 = csFactory.createFromName("EPSG:26710");
+    CoordinateReferenceSystem cs2 = csFactory.createFromParameters(null, "+proj=utm +zone=10 +datum=NAD27 +units=m +no_defs");
+    assertEquals(cs1, cs2);
+
+    CoordinateReferenceSystem cs3 = csFactory.createFromName("EPSG:26711");
+    assertNotEquals(cs1, cs3);
+  }
+}

--- a/src/test/java/org/locationtech/proj4j/proj/ProjectionGridRoundTripper.java
+++ b/src/test/java/org/locationtech/proj4j/proj/ProjectionGridRoundTripper.java
@@ -23,7 +23,7 @@ import org.locationtech.proj4j.ProjCoordinate;
 import org.locationtech.proj4j.proj.Projection;
 import org.locationtech.proj4j.util.ProjectionUtil;
 
-public class ProjectionGridRoundTripper 
+public class ProjectionGridRoundTripper
 {
 	private static final CoordinateTransformFactory ctFactory = new CoordinateTransformFactory();
   CRSFactory csFactory = new CRSFactory();
@@ -38,38 +38,36 @@ public class ProjectionGridRoundTripper
 	private boolean debug = false;
 	private int transformCount = 0;
 	private double[] gridExtent;
-	
+
 	public ProjectionGridRoundTripper(CoordinateReferenceSystem cs)
 	{
 		this.cs = cs;
-    transInverse = ctFactory.createTransform(cs, WGS84); 
-    transForward = ctFactory.createTransform(WGS84, cs); 
+    transInverse = ctFactory.createTransform(cs, WGS84);
+    transForward = ctFactory.createTransform(WGS84, cs);
 	}
-	
+
 	public void setLevelDebug(boolean debug)
 	{
 		this.debug = debug;
 	}
-	
+
 	public int getTransformCount()
 	{
 		return transformCount;
 	}
-	
+
 	public double[] getExtent()
 	{
 		return gridExtent;
 	}
 	public boolean runGrid(double tolerance)
 	{
-		boolean isWithinTolerance = true;
-		
 		gridExtent = gridExtent(cs.getProjection());
 		double minx = gridExtent[0];
 		double miny = gridExtent[1];
 		double maxx = gridExtent[2];
 		double maxy = gridExtent[3];
-		
+
     ProjCoordinate p = new ProjCoordinate();
 		double dx = (maxx - minx) / gridSize;
 		double dy = (maxy - miny) / gridSize;
@@ -82,7 +80,7 @@ public class ProjectionGridRoundTripper
 				 p.y = iy == gridSize ?
 						 	maxy
 					 		: miny + iy * dy;
-					 		
+
 				 boolean isWithinTol = roundTrip(p, tolerance);
 				 if (! isWithinTol)
 					 return false;
@@ -90,50 +88,50 @@ public class ProjectionGridRoundTripper
 		}
 		return true;
 	}
-	
+
   ProjCoordinate p2 = new ProjCoordinate();
   ProjCoordinate p3 = new ProjCoordinate();
 
 	private boolean roundTrip(ProjCoordinate p, double tolerance)
 	{
 		transformCount++;
-		
+
     transForward.transform(p, p2);
     transInverse.transform(p2, p3);
-		
-		if (debug) 
+
+		if (debug)
 			System.out.println(ProjectionUtil.toString(p) + " -> " + ProjectionUtil.toString(p2) + " ->  " + ProjectionUtil.toString(p3));
-		
+
 		double dx = Math.abs(p3.x - p.x);
 		double dy = Math.abs(p3.y - p.y);
-		
+
     boolean isInTol = dx <= tolerance && dy <= tolerance;
-    
-    if (! isInTol) 
+
+    if (! isInTol)
       System.out.println("FAIL: " + ProjectionUtil.toString(p) + " -> " + ProjectionUtil.toString(p2) + " ->  " + ProjectionUtil.toString(p3));
 
-    
+
 		return isInTol;
 	}
-	
+
 	public static double[] gridExtent(Projection proj)
 	{
 		// scan all lat/lon params to try and determine a reasonable extent
-		
+
 		double lon = proj.getProjectionLongitudeDegrees();
-		
+
 		double[] latExtent = new double[] {Double.MAX_VALUE, Double.MIN_VALUE };
 		updateLat(proj.getProjectionLatitudeDegrees(), latExtent);
 		updateLat(proj.getProjectionLatitude1Degrees(), latExtent);
 		updateLat(proj.getProjectionLatitude2Degrees(), latExtent);
-			
+
 		double centrex = lon;
 		double centrey = 0.0;
 		double gridWidth = 10;
-		
+
 		if (latExtent[0] < Double.MAX_VALUE && latExtent[1] > Double.MIN_VALUE) {
 			// got a good candidate
-			
+
 			double dlat = latExtent[1] - latExtent[0];
 			if (dlat > 0) gridWidth = 2 * dlat;
 		  centrey = (latExtent[1] + latExtent[0]) /2;
@@ -145,7 +143,7 @@ public class ProjectionGridRoundTripper
 		extent[3] = centrey + gridWidth/2;
 		return extent;
 	}
-	
+
 	private static void updateLat(double lat, double[] latExtent)
 	{
 		// 0.0 indicates not set (for most projections?)


### PR DESCRIPTION
This is follow-up PR to https://github.com/locationtech/proj4j/pull/33

Further testing revealed that `CoordinateReferenceSystem` was much too fragile because:
- The `CoordinateReferenceSystem` name changes depending on how it was constructed. For instance name may be `EPSG:3857` if CRS was constructed by EPSG code or `merc-CS` if it constructed from Proj4 string.
- Proj4 parameters are stored as provided. `+lat_0=0` and `+lat_0=0.0` are obviously the same but will trip up equality
- Proj4 parameters are stored in order provided, this will trip up array equality check
- Some parameters may be read from default file if `+no_def` is not present and thus will not be reflected in parameter string at all

So basically the situation is pretty dire and this PR attempts to remedy that.

It's worth noting that `Projection` class is highly mutable which makes checking for equality a little tricky. While the mutability is used primarily by the `Proj4Parser` to "build up" the projection its obviously possible that this is not the only place that mutation will happen because life.

In this PR:

- Base `Projection.equals` checks that left and right side are the same class. This represents the implementation of `project` method.
- Base `Projection.equals` checks the state of protected and private stateful fields that have setters
- Subclasses of `Projection` check equality of their additional stateful fields and delegate to super equality afterwards.
- `isSouth` and `heightOfOrbit` fields are moved to their corresponding subclasses. Getters and setters for those fields will throw `NoSuchElementException` if used at any other time.

Also ...
Closes: https://github.com/locationtech/proj4j/issues/38
