### PR TITLE
Minor hashCode/equals override improvements

### DIFF
--- a/src/main/java/org/locationtech/proj4j/datum/Datum.java
+++ b/src/main/java/org/locationtech/proj4j/datum/Datum.java
@@ -265,9 +265,4 @@ public class Datum implements java.io.Serializable {
     public void inverseShift(ProjCoordinate xy) {
         Grid.shift(grids, true, xy);
     }
-
-    @Override
-	public int hashCode() {
-			return Objects.hash(ellipsoid, grids, getTransformType());
-	}
 }

--- a/src/main/java/org/locationtech/proj4j/datum/Ellipsoid.java
+++ b/src/main/java/org/locationtech/proj4j/datum/Ellipsoid.java
@@ -359,6 +359,7 @@ public final class Ellipsoid implements Cloneable, java.io.Serializable {
         return name;
     }
 
+    @Override
     public int hashCode() {
         return name.hashCode()
                 | (7 * shortName.hashCode())
@@ -367,6 +368,7 @@ public final class Ellipsoid implements Cloneable, java.io.Serializable {
                 | (37 * Double.valueOf(eccentricity).hashCode());
     }
 
+    @Override
     public boolean equals(Object that) {
         if (this == that) return true;
         if (that instanceof Ellipsoid) {

--- a/src/main/java/org/locationtech/proj4j/units/Unit.java
+++ b/src/main/java/org/locationtech/proj4j/units/Unit.java
@@ -18,6 +18,7 @@ package org.locationtech.proj4j.units;
 
 import java.io.Serializable;
 import java.text.NumberFormat;
+import java.util.Objects;
 
 public class Unit implements Serializable {
 
@@ -93,4 +94,9 @@ public class Unit implements Serializable {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getClass(), name, value);
+    }
+    
 }

--- a/src/main/java/org/locationtech/proj4j/util/Pair.java
+++ b/src/main/java/org/locationtech/proj4j/util/Pair.java
@@ -15,6 +15,8 @@
  */
 package org.locationtech.proj4j.util;
 
+import java.util.Objects;
+
 public class Pair<A, B> {
 
     private A first;
@@ -70,6 +72,11 @@ public class Pair<A, B> {
         } else if (!second.equals(other.second))
             return false;
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getClass(), first, second);
     }
 
     public static <A, B> Pair<A, B> create(A first, B second) {


### PR DESCRIPTION
- Removed hashCode() override from Datum class - it does not override equals(), and should not override hashCode(). The isEqual() method could be renamed or rewritten to override equals, but is currently does not.
- Added hashCode() override to Unit class and Pair class.
- Added override annotations to Ellipsoid class for clarity.