### PR TITLE
support geocent

### DIFF
--- a/src/main/java/org/locationtech/proj4j/Registry.java
+++ b/src/main/java/org/locationtech/proj4j/Registry.java
@@ -194,6 +194,7 @@ public class Registry {
         register("fouc", FoucautProjection.class, "Foucaut");
         register("fouc_s", FoucautSinusoidalProjection.class, "Foucaut Sinusoidal");
         register("gall", GallProjection.class, "Gall (Gall Stereographic)");
+        register("geocent", GeocentProjection.class, "Geocentric");
         register("geos", GeostationarySatelliteProjection.class, "Geostationary Satellite");
 //    register( "gins8", Projection.class, "Ginsburg VIII (TsNIIGAiK)" );
 //    register( "gn_sinu", Projection.class, "General Sinusoidal Series" );

--- a/src/main/java/org/locationtech/proj4j/proj/GeocentProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/GeocentProjection.java
@@ -1,0 +1,14 @@
+package org.locationtech.proj4j.proj;
+
+import org.locationtech.proj4j.ProjCoordinate;
+import org.locationtech.proj4j.datum.GeocentricConverter;
+
+public class GeocentProjection extends Projection {
+
+  @Override
+  public ProjCoordinate projectRadians(ProjCoordinate src, ProjCoordinate dst) {
+    GeocentricConverter geocentricConverter = new GeocentricConverter(this.ellipsoid);
+    geocentricConverter.convertGeodeticToGeocentric(dst);
+    return dst;
+  }
+}


### PR DESCRIPTION
This is to support transforming into geocentric coordinate system.

https://github.com/locationtech/proj4j/blob/master/src/main/resources/proj4/nad/epsg#L11252
Currently, it is not able to transform to EPSG:4978.

`new CRSFactory().createFromName("EPSG:4978")`
> "Unknown projection: geocent"