### PR TITLE
Update OrthographicAzimuthalProjection

### DIFF
--- a/src/main/java/org/locationtech/proj4j/proj/OrthographicAzimuthalProjection.java
+++ b/src/main/java/org/locationtech/proj4j/proj/OrthographicAzimuthalProjection.java
@@ -41,23 +41,31 @@ public class OrthographicAzimuthalProjection extends AzimuthalProjection {
 		// it's better not to as they tend to crop up a lot up due to rounding errors.
 		switch (mode) {
 		case EQUATOR:
-//			if (cosphi * coslam < - EPS10)
+			if (cosphi * coslam < - EPS10) {
 //				throw new ProjectionException();
-			xy.y = Math.sin(phi);
+				xy.x = Double.NaN;
+				xy.y = Double.NaN;
+			} else
+				xy.y = Math.sin(phi);
 			break;
 		case OBLIQUE:
 			sinphi = Math.sin(phi);
-//			if (sinphi0 * (sinphi) + cosphi0 * cosphi * coslam < - EPS10)
-//				;
-//			   throw new ProjectionException();
-			xy.y = cosphi0 * sinphi - sinphi0 * cosphi * coslam;
+			if (sinphi0 * (sinphi) + cosphi0 * cosphi * coslam < - EPS10) {
+				//throw new ProjectionException();
+				xy.x = Double.NaN;
+				xy.y = Double.NaN;
+			} else
+				xy.y = cosphi0 * sinphi - sinphi0 * cosphi * coslam;
 			break;
 		case NORTH_POLE:
 			coslam = - coslam;
 		case SOUTH_POLE:
-//			if (Math.abs(phi - projectionLatitude) - EPS10 > MapMath.HALFPI)
+			if (Math.abs(phi - projectionLatitude) - EPS10 > Math.PI / 2) {
 //				throw new ProjectionException();
-			xy.y = cosphi * coslam;
+				xy.x = Double.NaN;
+				xy.y = Double.NaN;
+			} else
+				xy.y = cosphi * coslam;
 			break;
 		}
 		xy.x = cosphi * Math.sin(lam);


### PR DESCRIPTION
Set the projection result coordinate as NaN when the point is located at the back side of the earth. So the NaN coordinate points will not be drawed in visulization process. 

The points on the back side of the earth are invisible:
![image](https://user-images.githubusercontent.com/4408029/88483368-ec528b80-cf99-11ea-8b13-fd803c558c14.png)

The points on the back side of the earth are visible:
![image](https://user-images.githubusercontent.com/4408029/88483397-2facfa00-cf9a-11ea-97a1-ab6a37097ed8.png)

