### PR TITLE
Fix jdk11 javadocs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -74,7 +74,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -85,7 +85,7 @@
             <plugin>
                 <inherited>true</inherited>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -95,6 +95,7 @@
                         <configuration>
                             <failOnError>true</failOnError>
                             <failOnWarnings>false</failOnWarnings>
+                            <detectJavaApiLink>false</detectJavaApiLink>
                         </configuration>
                     </execution>
                 </executions>
@@ -102,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -115,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -138,7 +139,7 @@
             <!-- Maven Central Publish -->
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <deployAtEnd>true</deployAtEnd>
                 </configuration>

--- a/core/src/main/java/org/locationtech/proj4j/CRSFactory.java
+++ b/core/src/main/java/org/locationtech/proj4j/CRSFactory.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * This is the primary way of creating coordinate systems
  * for carrying out projections transformations.
  * <p>
- * <tt>CoordinateReferenceSystem</tt>s can be used to
+ * <code>CoordinateReferenceSystem</code>s can be used to
  * define {@link CoordinateTransform}s to perform transformations
  * on {@link ProjCoordinate}s.
  *
@@ -52,24 +52,24 @@ public class CRSFactory {
 
     /**
      * Creates a {@link CoordinateReferenceSystem} (CRS) from a well-known name.
-     * CRS names are of the form: "<tt>authority:code</tt>",
+     * CRS names are of the form: "<code>authority:code</code>",
      * with the components being:
      * <ul>
-     * <li><b><tt>authority</tt></b> is a code for a namespace supported by
+     * <li><b><code>authority</code></b> is a code for a namespace supported by
      * PROJ.4.
      * Currently supported values are
-     * <tt>EPSG</tt>,
-     * <tt>ESRI</tt>,
-     * <tt>WORLD</tt>,
-     * <tt>NA83</tt>,
-     * <tt>NAD27</tt>.
-     * If no authority is provided, the <tt>EPSG</tt> namespace is assumed.
-     * <li><b><tt>code</tt></b> is the id of a coordinate system in the authority namespace.
-     * For example, in the <tt>EPSG</tt> namespace a code is an integer value
+     * <code>EPSG</code>,
+     * <code>ESRI</code>,
+     * <code>WORLD</code>,
+     * <code>NA83</code>,
+     * <code>NAD27</code>.
+     * If no authority is provided, the <code>EPSG</code> namespace is assumed.
+     * <li><b><code>code</code></b> is the id of a coordinate system in the authority namespace.
+     * For example, in the <code>EPSG</code> namespace a code is an integer value
      * which identifies a CRS definition in the EPSG database.
      * (Codes are read and handled as strings).
      * </ul>
-     * An example of a valid CRS name is <tt>EPSG:3005</tt>.
+     * An example of a valid CRS name is <code>EPSG:3005</code>.
      * <p>
      *
      * @param name the name of a coordinate system, with optional authority prefix
@@ -95,7 +95,7 @@ public class CRSFactory {
      * +proj=aea +lat_1=50 +lat_2=58.5 +lat_0=45 +lon_0=-126 +x_0=1000000 +y_0=0 +ellps=GRS80 +units=m
      * </pre>
      *
-     * @param name     a name for this coordinate system (may be <tt>null</tt> for an anonymous coordinate system)
+     * @param name     a name for this coordinate system (may be <code>null</code> for an anonymous coordinate system)
      * @param paramStr a PROJ.4 projection parameter string
      * @return the specified {@link CoordinateReferenceSystem}
      * @throws UnsupportedParameterException if a given PROJ.4 parameter is not supported
@@ -110,7 +110,7 @@ public class CRSFactory {
      * Creates a {@link CoordinateReferenceSystem}
      * defined by an array of PROJ.4 projection parameters.
      * PROJ.4 parameters are generally of the form
-     * "<tt>+name=value</tt>".
+     * "<code>+name=value</code>".
      *
      * @param name   a name for this coordinate system (may be null)
      * @param params an array of PROJ.4 projection parameters
@@ -148,7 +148,7 @@ public class CRSFactory {
      * Finds a EPSG Code
      * defined by an array of PROJ.4 projection parameters.
      * PROJ.4 parameters are generally of the form
-     * "<tt>+name=value</tt>".
+     * "<code>+name=value</code>".
      *
      * @param params an array of PROJ.4 projection parameters
      * @return s String EPSG code

--- a/core/src/main/java/org/locationtech/proj4j/ProjCoordinate.java
+++ b/core/src/main/java/org/locationtech/proj4j/ProjCoordinate.java
@@ -57,7 +57,7 @@ public class ProjCoordinate implements Serializable {
 
     /**
      * The Z ordinate for this point.
-     * If this variable has the value <tt>Double.NaN</tt>
+     * If this variable has the value <code>Double.NaN</code>
      * then this coordinate does not have a Z value.
      * <p>
      * Note: This member variable
@@ -178,7 +178,7 @@ public class ProjCoordinate implements Serializable {
     /**
      * Sets the value of this coordinate to
      * be equal to the given ordinates.
-     * The Z ordinate is set to <tt>NaN</tt>.
+     * The Z ordinate is set to <code>NaN</code>.
      *
      * @param x the x ordinate
      * @param y the y ordinate
@@ -340,7 +340,7 @@ public class ProjCoordinate implements Serializable {
 
     /**
      * Returns a string representing the ProjPoint in the format:
-     * <tt>ProjCoordinate[X Y Z]</tt>.
+     * <code>ProjCoordinate[X Y Z]</code>.
      * <p>
      * Example:
      * <pre>
@@ -362,8 +362,8 @@ public class ProjCoordinate implements Serializable {
 
     /**
      * Returns a string representing the ProjPoint in the format:
-     * <tt>[X Y]</tt>
-     * or <tt>[X, Y, Z]</tt>.
+     * <code>[X Y]</code>
+     * or <code>[X, Y, Z]</code>.
      * Z is not displayed if it is NaN.
      * <p>
      * Example:

--- a/core/src/main/java/org/locationtech/proj4j/io/Proj4FileReader.java
+++ b/core/src/main/java/org/locationtech/proj4j/io/Proj4FileReader.java
@@ -105,7 +105,7 @@ public class Proj4FileReader {
 
     /**
      * Gets the list of PROJ.4 parameters which define
-     * the coordinate system specified by <tt>name</tt>.
+     * the coordinate system specified by <code>name</code>.
      *
      * @param crsName the name of the coordinate system
      * @return the PROJ.4 projection parameters which define the coordinate system

--- a/core/src/main/java/org/locationtech/proj4j/proj/Projection.java
+++ b/core/src/main/java/org/locationtech/proj4j/proj/Projection.java
@@ -370,7 +370,7 @@ public abstract class Projection implements Cloneable, java.io.Serializable {
 
     /**
      * Tests whether this projection has an inverse.
-     * If this method returns <tt>true</tt>
+     * If this method returns <code>true</code>
      * then the {@link #inverseProject(ProjCoordinate, ProjCoordinate)}
      * and {@link #inverseProjectRadians(ProjCoordinate, ProjCoordinate)}
      * methods will return meaningful results.

--- a/epsg/pom.xml
+++ b/epsg/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -67,7 +67,7 @@
             <plugin>
                 <inherited>true</inherited>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -77,6 +77,7 @@
                         <configuration>
                             <failOnError>true</failOnError>
                             <failOnWarnings>false</failOnWarnings>
+                            <detectJavaApiLink>false</detectJavaApiLink>
                         </configuration>
                     </execution>
                 </executions>
@@ -84,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -97,13 +98,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.1.0</version>
             </plugin>
 
             <!-- Maven Central Publish -->
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <updateReleaseInfo>true</updateReleaseInfo>
                 </configuration>


### PR DESCRIPTION
Eclipse Jenkins moved all-in to JDK11, this PR ensures we can build this project using it.