### PR TITLE
LCC ProjectInverse adjustment, BasicCoordinateTransform.transform cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed 
+- LCC ProjectInverse adjustment, BasicCoordinateTransform.transform cleanup [#117](https://github.com/locationtech/proj4j/pull/117)
+
+### Added
+- GeoAPI wrappers for PROJ4J [#115](https://github.com/locationtech/proj4j/pull/115)
+
 ## [1.3.0] - 2023-05-30
 
 ### Added

--- a/HOWTORELEASE.txt
+++ b/HOWTORELEASE.txt
@@ -67,7 +67,7 @@ General Notes
 
     Cheat sheet:
         - All commands are can be described via the following template:
-            mvn -P{eclipse | central} {-Dmaven.test.skip=true | } {-pl <module> | } {install, deploy, ...}
+            mvn -P{eclipse | central} {-Dmaven.test.skip=true | } {-pl <module> | } {install, deploy, ...} {-Dmaven.install.skip={false|true}}
 
     The description of the Sonatype publish process:
         - Snaphots:

--- a/core/src/main/java/org/locationtech/proj4j/BasicCoordinateTransform.java
+++ b/core/src/main/java/org/locationtech/proj4j/BasicCoordinateTransform.java
@@ -155,8 +155,9 @@ public class BasicCoordinateTransform implements CoordinateTransform {
 
         srcCRS.getProjection().getPrimeMeridian().toGreenwich(tgt);
 
+        // 'fix' commented out, see https://github.com/locationtech/proj4j/issues/116
         // fixes bug where computed Z value sticks around
-        tgt.clearZ();
+        // tgt.clearZ();
 
         if (doDatumTransform) {
             datumTransform(tgt);

--- a/core/src/main/java/org/locationtech/proj4j/proj/LambertConformalConicProjection.java
+++ b/core/src/main/java/org/locationtech/proj4j/proj/LambertConformalConicProjection.java
@@ -68,9 +68,11 @@ public class LambertConformalConicProjection extends ConicProjection {
 	}
 
 	public ProjCoordinate projectInverse(double x, double y, ProjCoordinate out) {
+		// https://github.com/OSGeo/PROJ/blob/9.6/src/projections/lcc.cpp#L49-L53
 		x /= scaleFactor;
 		y /= scaleFactor;
-		double rho = ProjectionMath.distance(x, y = rho0 - y);
+		y = rho0 - y;
+		double rho = ProjectionMath.distance(x, y);
 		if (rho != 0) {
 			if (n < 0.0) {
 				rho = -rho;
@@ -78,9 +80,9 @@ public class LambertConformalConicProjection extends ConicProjection {
 				y = -y;
 			}
 			if (spherical)
-				out.y = 2.0 * Math.atan(Math.pow(c / rho, 1.0/n)) - ProjectionMath.HALFPI;
+				out.y = 2.0 * Math.atan(Math.pow(c / rho, 1.0 / n)) - ProjectionMath.HALFPI;
 			else
-				out.y = ProjectionMath.phi2(Math.pow(rho / c, 1.0/n), e);
+				out.y = ProjectionMath.phi2(Math.pow(rho / c, 1.0 / n), e);
 			out.x = Math.atan2(x, y) / n;
 		} else {
 			out.x = 0.0;

--- a/core/src/test/java/org/locationtech/proj4j/CoordinateTransformTest.java
+++ b/core/src/test/java/org/locationtech/proj4j/CoordinateTransformTest.java
@@ -290,4 +290,14 @@ public class CoordinateTransformTest extends BaseCoordinateTransformTest {
                 "+proj=tmerc +lat_0=-36.87986527777778 +lon_0=174.7643393611111 +k=0.9999 +x_0=300000 +y_0=700000 +datum=nzgd49 +units=m +towgs84=59.47,-5.04,187.44,0.47,-0.1,1.024,-4.5993 +nadgrids=nzgd2kgrid0005.gsb +no_defs", 301062.2010778899, 210376.65974323952,
                 0.001);
     }
+
+    // https://github.com/locationtech/proj4j/issues/116
+    @Test
+    public void testEPSG_2994() {
+        checkTransform(
+                "EPSG:2994", new ProjCoordinate(635788, 850485, 81),
+                "+proj=geocent +datum=WGS84",
+                new ProjCoordinate(-2505627.3608, -3847384.25836, 4412472.6628),
+                0.001);
+    }
 }


### PR DESCRIPTION
LCC ProjectInverse fix, and BasicCoordinateTransform.transform z cord cleanup fix which is not needed.

transformToGeocentricFromWgs84 takes z into the account: https://github.com/locationtech/proj4j/blob/9016292021c8bd15b19a5df7f04ae4288defc986/core/src/main/java/org/locationtech/proj4j/datum/Datum.java#L236-L259 

Fixes https://github.com/locationtech/proj4j/issues/116 