### PR TITLE
External GridDefinition read fix

### DIFF
--- a/core/src/main/java/org/locationtech/proj4j/InvalidValueException.java
+++ b/core/src/main/java/org/locationtech/proj4j/InvalidValueException.java
@@ -28,4 +28,8 @@ public class InvalidValueException extends Proj4jException {
 	public InvalidValueException(String message) {
 		super(message);
 	}
+
+	public InvalidValueException(String message, Exception cause) {
+		super(message, cause);
+	}
 }

--- a/core/src/main/java/org/locationtech/proj4j/Proj4jException.java
+++ b/core/src/main/java/org/locationtech/proj4j/Proj4jException.java
@@ -34,4 +34,8 @@ public class Proj4jException extends RuntimeException
 	public Proj4jException(String message) {
 		super(message);
 	}
+
+	public Proj4jException(String message, Exception cause) {
+		super(message, cause);
+	}
 }

--- a/core/src/main/java/org/locationtech/proj4j/datum/Grid.java
+++ b/core/src/main/java/org/locationtech/proj4j/datum/Grid.java
@@ -376,7 +376,7 @@ public final class Grid implements Serializable {
         // search path for grid definition files, but for now we only check the
         // working directory and the classpath (in that order.)
         File file = new File(gridName);
-        if (file.exists()) return new DataInputStream(new FileInputStream(file));
+        if (file.exists()) return new DataInputStream(new BufferedInputStream(new FileInputStream(file)));
         InputStream resource = Grid.class.getResourceAsStream("/proj4/nad/" + gridName);
         if (resource != null) return new DataInputStream(new BufferedInputStream(resource));
 

--- a/core/src/main/java/org/locationtech/proj4j/parser/Proj4Parser.java
+++ b/core/src/main/java/org/locationtech/proj4j/parser/Proj4Parser.java
@@ -205,7 +205,7 @@ public class Proj4Parser {
             try {
                 datumParam.setGrids(Grid.fromNadGrids(nadgrids));
             } catch (IOException e) {
-                throw new InvalidValueException("Unknown nadgrid: " + nadgrids);
+                throw new InvalidValueException("Unknown nadgrid: " + nadgrids, e);
             }
         }
     }

--- a/core/src/test/java/org/locationtech/proj4j/datum/NTV2Test.java
+++ b/core/src/test/java/org/locationtech/proj4j/datum/NTV2Test.java
@@ -24,6 +24,8 @@ import org.locationtech.proj4j.CoordinateTransform;
 import org.locationtech.proj4j.CoordinateTransformFactory;
 import org.locationtech.proj4j.ProjCoordinate;
 
+import java.net.URISyntaxException;
+
 /**
  * Using grid shifts for Catalonia
  * @see https://geoinquiets.cat/
@@ -76,5 +78,19 @@ public class NTV2Test {
 
         Assert.assertTrue(expected2.areXOrdinatesEqual(result2, 0.001) &&
                           expected2.areYOrdinatesEqual(result2, 0.001));
+    }
+
+    @Test
+    public void nadGridExternalTest() throws URISyntaxException {
+        String path = this.getClass().getResource("/proj4/nad/100800401.gsb").toURI().getPath();
+        CRSFactory crsFactory = new CRSFactory();
+
+        CoordinateReferenceSystem tmercWithNadGridV2 =
+                crsFactory.createFromParameters("EPSG:2100",
+                        "+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000 +y_0=0 +ellps=GRS80 +towgs84=-199.87,74.79,246.62,0,0,0,0 +units=m +nadgrids="
+                                + path + " +no_defs"
+                );
+
+        Assert.assertEquals(Datum.TYPE_GRIDSHIFT, tmercWithNadGridV2.getDatum().getTransformType());
     }
 }


### PR DESCRIPTION
This PR fixes the read of the nadgrids passed into the proj4 string definition as an external / full path. Bug reported over here: https://github.com/locationtech/proj4j/issues/89#issuecomment-2974691702 

I also slightly readjusted the exception definition to pass down the original cause. 

The real issue was obfuscated via the exception thrown:

```java
org.locationtech.proj4j.InvalidValueException: Unknown nadgrid: /../proj4j/core/target/test-classes/proj4/nad/100800401.gsb

	at org.locationtech.proj4j.parser.Proj4Parser.parseDatum(Proj4Parser.java:208)
	at org.locationtech.proj4j.parser.Proj4Parser.parse(Proj4Parser.java:50)
	at org.locationtech.proj4j.CRSFactory.createFromParameters(CRSFactory.java:127)
	at org.locationtech.proj4j.CRSFactory.createFromParameters(CRSFactory.java:106)
	at org.locationtech.proj4j.datum.NTV2Test.nadGridExternalTest(NTV2Test.java:89)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:231)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.io.IOException: mark/reset not supported
	at java.base/java.io.InputStream.reset(InputStream.java:741)
	at java.base/java.io.FilterInputStream.reset(FilterInputStream.java:216)
	at org.locationtech.proj4j.datum.Grid.gridinfoInit(Grid.java:350)
	at org.locationtech.proj4j.datum.Grid.mergeGridFile(Grid.java:76)
	at org.locationtech.proj4j.datum.Grid.fromNadGrids(Grid.java:323)
	at org.locationtech.proj4j.parser.Proj4Parser.parseDatum(Proj4Parser.java:206)
```