### PR TITLE
build: add JPMS Automatic-Module-Name to JAR manifest

### DIFF
--- a/geoapi/pom.xml
+++ b/geoapi/pom.xml
@@ -73,6 +73,18 @@
                     <excludePackageNames>org.locationtech.proj4j.geoapi.spi</excludePackageNames>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.locationtech.proj4j.geoapi</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.0</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
+            </plugin>
 
             <!-- Maven Central Publish -->
             <plugin>


### PR DESCRIPTION
Configure the maven-jar-plugin to add an Automatic-Module-Name entry (org.locationtech.proj4j.geoapi) to the JAR manifest.

This provides a stable and explicit JPMS module name for consumers using the Java module system, instead of relying on the automatically derived name based on the JAR file name. It also improves Gradle JPMS support: Gradle only puts dependencies on the module path if they either contain a module-info.class or declare an Automatic-Module-Name. Without this entry, this artifact is always kept on the classpath in modular Gradle builds and cannot be required by name from module-info.java.