### PR TITLE
Add JPMS Automatic-Module-Name to core and epsg JAR manifests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,6 +48,7 @@
                         <_nouses>true</_nouses>
                         <_snapshot>${osgi-version-qualifier}</_snapshot>
                         <Bundle-SymbolicName>${bundle-symbolicname}</Bundle-SymbolicName>
+                        <Automatic-Module-Name>org.locationtech.proj4j</Automatic-Module-Name>
                         <Import-Package />
                     </instructions>
                     <niceManifest>true</niceManifest>

--- a/epsg/pom.xml
+++ b/epsg/pom.xml
@@ -24,4 +24,19 @@
         </license>
     </licenses>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.locationtech.proj4j.epsg</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Follows up https://github.com/locationtech/proj4j/pull/123 and adds Automatic-Module-Name entry into all the proj4j artifacts. 

Reported in here https://github.com/locationtech/proj4j/pull/123#issuecomment-4603574838 by @soc 