### PR TITLE
Fix Oblique Mercator natural-origin offset to use the central-line azimuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Oblique Mercator: compute the natural-origin (uc) offset from the central-line azimuth (`+alpha`) instead of the rectified bearing (`+gamma`), so the projection centre maps to the false easting/northing when `+gamma` differs from `+alpha` (e.g. an explicit `+gamma=0` with a non-zero azimuth)
+
 ## [1.4.3] - 2026-06-02
 
 ### Added

--- a/core/src/main/java/org/locationtech/proj4j/proj/ObliqueMercatorProjection.java
+++ b/core/src/main/java/org/locationtech/proj4j/proj/ObliqueMercatorProjection.java
@@ -158,8 +158,12 @@ public class ObliqueMercatorProjection extends CylindricalProjection {
 		sinrot = Math.sin(Gamma);
 		cosrot = Math.cos(Gamma);
 		
+		// The natural-origin offset uses the azimuth of the central line (alpha), following Snyder's
+		// Hotine Oblique Mercator: u_c = (A / B) * atan(sqrt(D^2 - 1) / cos(alpha_c)). Using the
+		// rectified bearing (Gamma) here misplaces the projection centre whenever Gamma != alpha,
+		// e.g. for definitions with an explicit "+gamma=0" and a non-zero azimuth.
 		u_0 = no_uoff ? 0. :
-			Math.abs(al * Math.atan(Math.sqrt(d * d - 1.) / cosrot) / bl);
+			Math.abs(al * Math.atan(Math.sqrt(d * d - 1.) / Math.cos(alpha)) / bl);
 		if (projectionLatitude < 0.)
 			u_0 = - u_0;
 	}

--- a/core/src/test/java/org/locationtech/proj4j/Proj4VariousTest.java
+++ b/core/src/test/java/org/locationtech/proj4j/Proj4VariousTest.java
@@ -91,6 +91,19 @@ public class Proj4VariousTest extends BaseCoordinateTransformTest {
                 1e-5);
     }
 
+    @Test
+    public void testObliqueMercatorExplicitGamma() {
+        // Hotine Oblique Mercator with an explicit "+gamma=0" and a non-zero azimuth. The natural
+        // origin offset must place the projection centre (lonc, lat_0) exactly at the false
+        // easting/northing; a regression here shifted the centre by ~2.5 km. Reference coordinates
+        // computed with PROJ.
+        String omerc =
+                "+proj=omerc +lat_0=-20 +lonc=140 +alpha=30 +gamma=0 +k=1 +x_0=200000 +y_0=300000 +ellps=GRS80 +units=m";
+        checkTransform("+proj=latlong +ellps=GRS80", p("140 -20"), omerc, p("200000.00 300000.00"), 1e-2);
+        checkTransform("+proj=latlong +ellps=GRS80", p("140.5 -20.2"), omerc, p("256366.4343 306886.2489"), 1e-2);
+        checkTransform("+proj=latlong +ellps=GRS80", p("139.7 -19.8"), omerc, p("161721.1705 303433.2577"), 1e-2);
+    }
+
     // disabled - gamma param not implemented
 //    @Test
     public void XXX_testRSOBorneo() {


### PR DESCRIPTION
## Summary

Fixes the Oblique Mercator (`+proj=omerc`) natural-origin offset so that the projection centre maps to the false easting/northing when `+gamma` differs from `+alpha` — in particular for definitions with an explicit `+gamma=0` and a non-zero azimuth (the ESRI "Local" / mine-grid convention).

## Root cause

In `ObliqueMercatorProjection.initialize()`, the natural-origin (`uc`) offset is computed with `cosrot = cos(Gamma)` (the *rectified bearing* γ):

```java
u_0 = no_uoff ? 0. :
    Math.abs(al * Math.atan(Math.sqrt(d * d - 1.) / cosrot) / bl);
```

Snyder's Hotine Oblique Mercator (and PROJ) define this offset from the **central-line azimuth** α:

```
u_c = (A / B) * atan( sqrt(D^2 - 1) / cos(alpha_c) )
```

`project()` computes the point's along-line coordinate from the natural azimuth (`singam`/`cosgam`), so the offset must be based on α, not γ. When γ = α the two coincide (the common case, and why this went unnoticed — e.g. the standard EPSG omerc grids store `+gamma` equal to `+alpha`). But when γ ≠ α — e.g. `+gamma=0` with a non-zero azimuth — `u_0` no longer cancels the centre's coordinate, and the centre is displaced along the central line.

## Impact (before the fix)

For a grid like `+proj=omerc +lat_0=-20 +lonc=140 +alpha=30 +gamma=0 +k=1 +x_0=200000 +y_0=300000 +ellps=GRS80`, the centre `(140, -20)` should map to `(200000, 300000)`. Before the fix it was off by ~2.5 km in the along-line direction (larger for larger azimuths). This is the ESRI `PROJECTION["Local"]` mine-grid convention (origin + scale + azimuth, no rectification), which is common for Australian survey grids.

## Fix

Use `cos(alpha)` for the offset. This is a **no-op when γ == α** (verified by the full existing test suite) and matches PROJ output when γ ≠ α.

## Test

Adds `Proj4VariousTest#testObliqueMercatorExplicitGamma`, covering `+gamma=0` with a non-zero azimuth. It asserts the centre maps exactly to the false easting/northing and checks two further points; reference coordinates were computed with PROJ. With the fix the centre error is 0 and the points agree with PROJ to < 1e-4 m; before the fix the centre was ~2.5 km off.

Full `core` suite: 65 run, 0 failures, 0 errors, 2 skipped (pre-existing).

## Related note (not addressed here)

The `Gamma` field defaults to `0.0` rather than `NaN`, so the `gzi = Double.isNaN(Gamma)` guard is always "provided" and the `if (gzi == 0) Gamma = alpha;` default (rectified bearing defaults to the azimuth when `+gamma` is omitted) never runs. That affects the *rotation* for the `+gamma`-omitted case and the unreachable two-point setup. I've kept this PR focused on the offset bug; happy to open a separate issue/PR for the `Gamma` default if useful.
